### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       # Checkout the code


### PR DESCRIPTION
Potential fix for [https://github.com/MarTrepodi/mhanndalorian-bot-api/security/code-scanning/1](https://github.com/MarTrepodi/mhanndalorian-bot-api/security/code-scanning/1)

Add an explicit `permissions` block to the `release` job in `.github/workflows/release.yml`.

Best fix without changing functionality:
- Define only the scopes this job needs.
- Since the job pushes git tags (`git push origin "v$VERSION"`), it needs `contents: write`.
- Add the permissions at the `release` job level (right under `runs-on`) so this job is explicitly constrained/documented while leaving `pypi-publish` permissions unchanged.

File/region to change:
- `.github/workflows/release.yml`
- In `jobs.release`, immediately after `runs-on: ubuntu-latest`, add:
  - `permissions:`
  - `contents: write`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
