### PR TITLE
Phase 1 of v0.11.0 refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,7 @@ jobs:
         run: uv sync
 
       - name: Run ty
-        # Allowed to fail until the codebase is fully typed. Remove `|| true`
-        # once existing type errors are resolved.
-        run: uvx ty check mhanndalorian_bot/ || true
+        run: uvx ty check mhanndalorian_bot/
 
   # ── Test ───────────────────────────────────────────────────────────────
   test:

--- a/README.md
+++ b/README.md
@@ -130,4 +130,4 @@ if __name__ == '__main__':
 ```
 
 More information can be found
-on [GitHub](https://github.com/MarTrepodi/mhanndalorian-bot-api/tree/main/Library_Details.md)
+on [GitHub](https://github.com/MarTrepodi/mhanndalorian-bot-api/blob/main/Library_Details.md)

--- a/mhanndalorian_bot/attrs.py
+++ b/mhanndalorian_bot/attrs.py
@@ -102,8 +102,6 @@ class Headers(dict):
         if key in self:
             del self[key]
 
-    pop = delete_header
-
 
 class Payload(dict):
 

--- a/mhanndalorian_bot/base.py
+++ b/mhanndalorian_bot/base.py
@@ -73,7 +73,8 @@ class MBot:
         if discord_id:
             self.set_discord_id(discord_id)
 
-        self.debug = debug
+        if debug is not None:
+            self.debug = debug
 
         if isinstance(api_host, str):
             self.set_api_host(api_host)
@@ -303,4 +304,6 @@ class MBot:
         self.client.headers = self.headers
         self.aclient.headers = self.headers
         if debug_enabled:
-            self.logger.debug(f"HTTP client headers updated with HMAC signature: {_redact_headers(self.client.headers)}")
+            self.logger.debug(
+                f"HTTP client headers updated with HMAC signature: {_redact_headers(self.client.headers)}"
+            )

--- a/mhanndalorian_bot/registry.py
+++ b/mhanndalorian_bot/registry.py
@@ -28,7 +28,7 @@ class Registry(MBot):
                          api_host=api_host, hmac=hmac, debug=debug, verify=verify)
 
     @func_timer
-    def validate_arguments(self, allycode: str, discord_id: str) -> str:
+    def validate_arguments(self, allycode: str | None, discord_id: str | None) -> str:
         """Validate provided arguments for the player registry service"""
         if not allycode and not discord_id:
             raise ValueError("At least one of allycode or discord_id must be provided.")
@@ -36,10 +36,12 @@ class Registry(MBot):
         if allycode and discord_id:
             raise ValueError("Only one of allycode or discord_id can be provided.")
 
-        allycode = self.cleanse_allycode(allycode) if allycode else None
-        discord_id = self.cleanse_discord_id(discord_id) if discord_id else None
+        cleansed_allycode = self.cleanse_allycode(allycode) if allycode else None
+        cleansed_discord_id = self.cleanse_discord_id(discord_id) if discord_id else None
 
-        return allycode or discord_id
+        identifier = cleansed_allycode or cleansed_discord_id
+        assert identifier is not None  # guaranteed by the checks above
+        return identifier
 
     @func_timer
     def fetch_player(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "hatchling>=1.27.0",
     "httpx",
-    "pytest>=8.4.2",
     "sentinels",
 ]
 
@@ -58,7 +56,24 @@ style = "pep440"
 vsc = "git"
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["mhanndalorian_bot"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+# Keep the default rule set (E, F) for now. Broaden in a follow-up PR
+# (likely add I, B, UP) once existing violations are addressed.
+select = ["E", "F"]
+
+[tool.ty.environment]
+python-version = "3.10"
+python = ".venv"
+
+[tool.ty.src]
+include = ["mhanndalorian_bot"]
+
 
 [tool.semantic_release]
 version_variable = [

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -39,7 +39,12 @@ def test_register_player_invalid_data(registry_instance):
 
 def test_verify_player_valid_data(registry_instance):
     """Test verifying a player with valid discord ID and allycode."""
-    result = registry_instance.verify_player(discord_id="123456789987654321", allycode="123-456-789", primary=False, hmac=True)
+    result = registry_instance.verify_player(
+        discord_id="123456789987654321",
+        allycode="123-456-789",
+        primary=False,
+        hmac=True,
+    )
     assert isinstance(result, bool)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -184,22 +184,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hatchling"
-version = "1.29.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pluggy" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "trove-classifiers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/9c/b4cfe330cd4f49cff17fd771154730555fa4123beb7f292cf0098b4e6c20/hatchling-1.29.0.tar.gz", hash = "sha256:793c31816d952cee405b83488ce001c719f325d9cda69f1fc4cd750527640ea6", size = 55656, upload-time = "2026-02-23T19:42:06.539Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl", hash = "sha256:50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0", size = 76356, upload-time = "2026-02-23T19:42:05.197Z" },
-]
-
-[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -249,9 +233,7 @@ wheels = [
 name = "mhanndalorian-bot"
 source = { editable = "." }
 dependencies = [
-    { name = "hatchling" },
     { name = "httpx" },
-    { name = "pytest" },
     { name = "sentinels" },
 ]
 
@@ -265,9 +247,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "hatchling", specifier = ">=1.27.0" },
     { name = "httpx" },
-    { name = "pytest", specifier = ">=8.4.2" },
     { name = "sentinels" },
 ]
 
@@ -286,15 +266,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -439,15 +410,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
-]
-
-[[package]]
-name = "trove-classifiers"
-version = "2026.5.7.17"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/68/175e7c07c5be13200387d5c0995b0da1e198e360047c08eb17d1002fcd92/trove_classifiers-2026.5.7.17.tar.gz", hash = "sha256:a04a48f8f0a787cb996514d3969ac7608aa3c60cb15d073c1e02801e60533e80", size = 17041, upload-time = "2026-05-07T17:48:01.931Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/e3/d81b065a2d866a33a541ac63a2a4cc5737e03ce2379ac3191c98bb8867e3/trove_classifiers-2026.5.7.17-py3-none-any.whl", hash = "sha256:5ec0800de5e2ddbd7c663cb4c0c15328f132dc168813897c18866c5c7b93db33", size = 14201, upload-time = "2026-05-07T17:48:00.488Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

PR-1 of the v0.11.0 hardening series.

- pyproject.toml: drop pytest>=8.4.2 and hatchling>=1.27.0 from [project] dependencies (pytest is dev-only; hatchling is build-only via [build-system] requires).
- pyproject.toml: change [tool.hatch.build.targets.wheel] packages from ["."] to ["mhanndalorian_bot"] so the wheel no longer ships .github/, tests/, examples/, or any repo-root extras.
- pyproject.toml: add minimal [tool.ruff] (line-length 120, default E+F rules) and [tool.ty] config sections.
- Fix the four pre-existing ty type errors:
  - attrs.py: drop the LSP-violating 'pop = delete_header' alias (no callers).
  - base.py: guard 'self.debug = debug' with 'if debug is not None' since the parameter is annotated bool | None.
  - registry.py.validate_arguments: parameters are now str | None to match actual call sites; rename locals to avoid reassigning a str-typed binding to None.
- ci.yml: drop '|| true' from 'Run ty' step now that the type errors are resolved.
- README.md: fix broken Library_Details.md link (tree -> blob).
- Refresh uv.lock to drop hatchling + transitive (pathspec, trove-classifiers).
- Minor: two pre-existing long lines reformatted to satisfy ruff E501.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation
- [ ] Tests

## Checklist

- [ ] My commits follow the [Angular commit convention](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, etc.)
- [ ] I have added/updated docstrings with type hints for any new or changed public methods
- [ ] I have added unit tests that cover my changes (mocked, not requiring live external services)
- [ ] All existing tests still pass (`uv run pytest tests/ -v`)
- [ ] Ruff linter passes (`uv run ruff check mhanndalorian_bot/ tests/`)
- [ ] I have not bundled unrelated changes in this PR
